### PR TITLE
Fix test comparison.

### DIFF
--- a/project/tests/test_user_model.py
+++ b/project/tests/test_user_model.py
@@ -29,7 +29,7 @@ class TestUserModel(BaseTestCase):
         user = add_user('justatest', 'test@test.com', 'test')
         auth_token = user.encode_auth_token(user.id)
         self.assertTrue(isinstance(auth_token, bytes))
-        self.assertTrue(User.decode_auth_token(auth_token), user.id)
+        self.assertEqual(User.decode_auth_token(auth_token), user.id)
 
     def test_add_user_duplicate_username(self):
         add_user('justatest', 'test@test.com', 'test')


### PR DESCRIPTION
Minor change to `test_decode_auth_token` to use the correct assertion.  The `auth_token` decodes to the `user.id` so they should `assertEqual` should be used.